### PR TITLE
Request collaboration on krafix for Metal

### DIFF
--- a/Sources/CStyleTranslator.cpp
+++ b/Sources/CStyleTranslator.cpp
@@ -16,7 +16,7 @@ CStyleTranslator::CStyleTranslator(std::vector<unsigned>& spirv, EShLanguage sta
 
 CStyleTranslator::~CStyleTranslator() {
 	// Delete any function objects that were added to the function pointer vector
-	for (auto iter = functions.begin(), end = functions.end(); iter != end; iter++) {
+	for (std::vector<Function*>::iterator iter = functions.begin(), end = functions.end(); iter != end; iter++) {
 		delete *iter;
 	}
 	functions.clear();

--- a/Sources/CStyleTranslator.cpp
+++ b/Sources/CStyleTranslator.cpp
@@ -268,38 +268,34 @@ void CStyleTranslator::outputInstruction(const Target& target, std::map<std::str
 		break;
 	}
 	case OpTypePointer: {
-		Type t;
 		unsigned id = inst.operands[0];
-		Type subtype = types[inst.operands[2]];
-		t.name = subtype.name;
-		t.isarray = subtype.isarray;
-		t.length = subtype.length;
-		types[id] = t;
+		unsigned reftype = inst.operands[2];
+		types[id] = types[reftype];	// Pass through referenced type
 		break;
 	}
 	case OpTypeFloat: {
-		Type t;
+		Type t(inst.opcode);
 		unsigned id = inst.operands[0];
 		t.name = "float";
 		types[id] = t;
 		break;
 	}
 	case OpTypeInt: {
-		Type t;
+		Type t(inst.opcode);
 		unsigned id = inst.operands[0];
 		t.name = "int";
 		types[id] = t;
 		break;
 	}
 	case OpTypeBool: {
-		Type t;
+		Type t(inst.opcode);
 		unsigned id = inst.operands[0];
 		t.name = "bool";
 		types[id] = t;
 		break;
 	}
 	case OpTypeStruct: {
-		Type t;
+		Type t(inst.opcode);
 		unsigned id = inst.operands[0];
 		// TODO: members
 		Name n = names[id];
@@ -359,7 +355,7 @@ void CStyleTranslator::outputInstruction(const Target& target, std::map<std::str
 		break;
 	}
 	case OpTypeArray: {
-		Type t;
+		Type t(inst.opcode);
 		t.name = "unknownarray";
 		t.isarray = true;
 		unsigned id = inst.operands[0];
@@ -383,7 +379,7 @@ void CStyleTranslator::outputInstruction(const Target& target, std::map<std::str
 		break;
 	}
 	case OpTypeVector: {
-		Type t;
+		Type t(inst.opcode);
 		unsigned id = inst.operands[0];
 		t.name = "vec?";
 		Type subtype = types[inst.operands[1]];
@@ -405,7 +401,7 @@ void CStyleTranslator::outputInstruction(const Target& target, std::map<std::str
 		break;
 	}
 	case OpTypeMatrix: {
-		Type t;
+		Type t(inst.opcode);
 		unsigned id = inst.operands[0];
 		t.name = "mat?";
 		Type subtype = types[inst.operands[1]];
@@ -429,7 +425,7 @@ void CStyleTranslator::outputInstruction(const Target& target, std::map<std::str
 		break;
 	}
 	case OpTypeImage: {
-		Type t;
+		Type t(inst.opcode);
 		unsigned id = inst.operands[0];
 		bool video = inst.length >= 8 && inst.operands[8] == 1;
 		if (video && target.system == Android) {
@@ -445,10 +441,11 @@ void CStyleTranslator::outputInstruction(const Target& target, std::map<std::str
 		break;
 	}
 	case OpTypeSampledImage: {
-		Type t;
 		unsigned id = inst.operands[0];
 		unsigned image = inst.operands[1];
-		types[id] = types[image];
+		Type t = types[image];		// Pass through image type...
+		t.opcode = inst.opcode;		// ...except OpCode.
+		types[id] = t;
 		break;
 	}
 	case OpVariable: {
@@ -849,7 +846,7 @@ void CStyleTranslator::outputInstruction(const Target& target, std::map<std::str
 		break;
 	}
 	case OpTypeFunction: {
-		Type t;
+		Type t(inst.opcode);
 		unsigned id = inst.operands[0];
 		t.name = "function";
 		types[id] = t;

--- a/Sources/CStyleTranslator.cpp
+++ b/Sources/CStyleTranslator.cpp
@@ -263,6 +263,7 @@ void CStyleTranslator::outputInstruction(const Target& target, std::map<std::str
 	using namespace spv;
 
 	switch (inst.opcode) {
+
 	case OpName: {
 		unsigned id = inst.operands[0];
 		if (strcmp(inst.string, "") != 0) {
@@ -1161,6 +1162,10 @@ void CStyleTranslator::outputInstruction(const Target& target, std::map<std::str
 	case OpSource:
 		break;
 	case OpCapability:
+		break;
+	case OpString:
+		break;
+	case OpSourceExtension:
 		break;
 	default:
 		output(out);

--- a/Sources/CStyleTranslator.cpp
+++ b/Sources/CStyleTranslator.cpp
@@ -829,8 +829,22 @@ void CStyleTranslator::outputInstruction(const Target& target, std::map<std::str
 	case OpDecorate: {
 		unsigned target = inst.operands[0];
 		Decoration decoration = (Decoration)inst.operands[1];
-		if (decoration == DecorationBuiltIn) {
-			variables[target].builtin = true;
+		switch (decoration) {
+			case DecorationBuiltIn:
+				variables[target].builtin = true;
+				variables[target].builtinType = inst.operands[2];
+				break;
+			case DecorationLocation:
+				variables[target].location = inst.operands[2];
+				break;
+			case DecorationDescriptorSet:
+				variables[target].descriptorSet = inst.operands[2];
+				break;
+			case DecorationBinding:
+				variables[target].binding = inst.operands[2];
+				break;
+			default:
+				break;
 		}
 		break;
 	}

--- a/Sources/CStyleTranslator.cpp
+++ b/Sources/CStyleTranslator.cpp
@@ -326,6 +326,12 @@ void CStyleTranslator::outputInstruction(const Target& target, std::map<std::str
 		unsigned mbrId = getMemberId(typeId, member);
 		Decoration decoration = (Decoration)inst.operands[2];
 		switch (decoration) {
+			case DecorationBuiltIn: {
+				Member& mbr = members[mbrId];
+				mbr.builtin = true;
+				mbr.builtinType = (BuiltIn)inst.operands[3];
+				break;
+			}
 			case spv::DecorationColMajor:
 				members[mbrId].isColumnMajor = true;
 				break;
@@ -862,10 +868,12 @@ void CStyleTranslator::outputInstruction(const Target& target, std::map<std::str
 		unsigned target = inst.operands[0];
 		Decoration decoration = (Decoration)inst.operands[1];
 		switch (decoration) {
-			case DecorationBuiltIn:
-				variables[target].builtin = true;
-				variables[target].builtinType = (BuiltIn)inst.operands[2];
+			case DecorationBuiltIn: {
+				Variable& var = variables[target];
+				var.builtin = true;
+				var.builtinType = (BuiltIn)inst.operands[2];
 				break;
+			}
 			case DecorationLocation:
 				variables[target].location = inst.operands[2];
 				break;

--- a/Sources/CStyleTranslator.cpp
+++ b/Sources/CStyleTranslator.cpp
@@ -31,6 +31,11 @@ void CStyleTranslator::output(std::ostream* out) {
 	indent(out);
 }
 
+bool CStyleTranslator::argComma(std::ostream* out, bool needsComma) {
+	if (needsComma) { (*out) << ", "; }
+	return true;
+}
+
 std::string CStyleTranslator::getReference(id _id) {
 	if (references.find(_id) == references.end()) {
 		std::stringstream str;

--- a/Sources/CStyleTranslator.h
+++ b/Sources/CStyleTranslator.h
@@ -9,11 +9,15 @@ namespace krafix {
 	struct Variable {
 		unsigned id;
 		unsigned type;
+		unsigned builtinType;
+		unsigned location;
+		unsigned descriptorSet;
+		unsigned binding;
 		spv::StorageClass storage;
 		bool builtin;
 		bool declared;
 
-		Variable() : builtin(false) {}
+		Variable() : builtin(false), location(0), descriptorSet(0), binding(0) {}
 	};
 
 	struct Type {

--- a/Sources/CStyleTranslator.h
+++ b/Sources/CStyleTranslator.h
@@ -130,6 +130,7 @@ namespace krafix {
 	protected:
 		std::ostream* out;
 		std::map<unsigned, Name> names;
+		std::map<unsigned, std::string> uniqueNames;
 		std::map<unsigned, Type> types;
 		std::map<unsigned, Variable> variables;
 		std::map<unsigned, Member> members;
@@ -155,5 +156,9 @@ namespace krafix {
 		void output(std::ostream* out);
 		std::string getReference(unsigned _id);
 		inline unsigned getMemberId(unsigned typeId, unsigned member) { return (typeId << 16) + member; }
+		void addUniqueName(unsigned id, const char* name);
+		std::string& getUniqueName(unsigned id, const char* prefix);
+		std::string& getVariableName(unsigned id);
+		std::string& getFunctionName(unsigned id);
 	};
 }

--- a/Sources/CStyleTranslator.h
+++ b/Sources/CStyleTranslator.h
@@ -122,7 +122,7 @@ namespace krafix {
 	class CStyleTranslator : public Translator {
 	public:
 		CStyleTranslator(std::vector<unsigned>& spirv, EShLanguage stage);
-		virtual ~CStyleTranslator() {}
+		virtual ~CStyleTranslator();
 		virtual void outputInstruction(const Target& target, std::map<std::string, int>& attributes, Instruction& inst);
 		virtual void outputLibraryInstruction(const Target& target, std::map<std::string, int>& attributes, Instruction& inst, GLSLstd450 entrypoint);
 		void startFunction(std::string name);
@@ -153,7 +153,6 @@ namespace krafix {
 		virtual std::string indexName(const std::vector<unsigned>& indices);
 		void indent(std::ostream* out);
 		void output(std::ostream* out);
-		bool argComma(std::ostream* out, bool needsComma);
 		std::string getReference(unsigned _id);
 		inline unsigned getMemberId(unsigned typeId, unsigned member) { return (typeId << 16) + member; }
 	};

--- a/Sources/CStyleTranslator.h
+++ b/Sources/CStyleTranslator.h
@@ -79,6 +79,46 @@ namespace krafix {
 		bool loop;
 	};
 
+#define ExecutionModeDefault  ( (spv::ExecutionMode) -1 )
+
+	struct ExecutionModes {
+		unsigned invocationCount;
+		spv::ExecutionMode spacingType;
+		spv::ExecutionMode vertexOrder;
+		spv::ExecutionMode originOrientation;
+		spv::ExecutionMode depthModificationType;
+		spv::ExecutionMode primitiveType;
+		spv::ExecutionMode outputPrimitiveType;
+		unsigned localSize[3];
+		unsigned localSizeHint[3];
+		unsigned maxVertexCount;
+		unsigned vectorTypeHint;
+		bool usePixelCenterInteger;
+		bool useEarlyFragmentTests;
+		bool useTessellationPoints;
+		bool useTransformFeedback;
+		bool useDepthModification;
+		bool disallowContractions;
+
+		ExecutionModes() : localSize{0, 0, 0}, localSizeHint{0, 0, 0} {
+			invocationCount = 1;
+			spacingType = ExecutionModeDefault;
+			vertexOrder = ExecutionModeDefault;
+			originOrientation = ExecutionModeDefault;
+			depthModificationType = ExecutionModeDefault;
+			primitiveType = ExecutionModeDefault;
+			outputPrimitiveType = ExecutionModeDefault;
+			maxVertexCount = 0;
+			vectorTypeHint = 0;
+			usePixelCenterInteger = false;
+			useEarlyFragmentTests = false;
+			useTessellationPoints = false;
+			useTransformFeedback = false;
+			useDepthModification = false;
+			disallowContractions = false;
+		}
+	};
+
 	class CStyleTranslator : public Translator {
 	public:
 		CStyleTranslator(std::vector<unsigned>& spirv, EShLanguage stage);
@@ -99,6 +139,7 @@ namespace krafix {
 		std::map<unsigned, std::vector<unsigned>> compositeInserts;
 		std::vector<Parameter> parameters;
 		std::vector<unsigned> callParameters;
+		ExecutionModes executionModes;
 		int indentation = 0;
 		bool outputting = false;
 		bool firstFunction = true;
@@ -112,6 +153,7 @@ namespace krafix {
 		virtual std::string indexName(const std::vector<unsigned>& indices);
 		void indent(std::ostream* out);
 		void output(std::ostream* out);
+		bool argComma(std::ostream* out, bool needsComma);
 		std::string getReference(unsigned _id);
 		inline unsigned getMemberId(unsigned typeId, unsigned member) { return (typeId << 16) + member; }
 	};

--- a/Sources/CStyleTranslator.h
+++ b/Sources/CStyleTranslator.h
@@ -54,6 +54,8 @@ namespace krafix {
 	struct Member {
 		unsigned type;
 		const char* name;
+		spv::BuiltIn builtinType;
+		bool builtin;
 		bool isColumnMajor;
 
 		Member() : name("unknown"), isColumnMajor(true) {}

--- a/Sources/CStyleTranslator.h
+++ b/Sources/CStyleTranslator.h
@@ -16,7 +16,7 @@ namespace krafix {
 	struct Variable {
 		unsigned id;
 		unsigned type;
-		unsigned builtinType;
+		spv::BuiltIn builtinType;
 		unsigned location;
 		unsigned descriptorSet;
 		unsigned binding;
@@ -24,12 +24,13 @@ namespace krafix {
 		bool builtin;
 		bool declared;
 
-		Variable() : builtin(false), location(0), descriptorSet(0), binding(0) {}
+		Variable() : id(0), type(0), builtin(false), location(0), descriptorSet(0), binding(0) {}
 	};
 
 	struct Type {
 		spv::Op opcode;
 		const char* name;
+		unsigned baseType;
 		unsigned length;
 		SampledImage sampledImage;
 		spv::Dim imageDim;
@@ -39,6 +40,7 @@ namespace krafix {
 
 		Type(spv::Op opcode) : opcode(opcode)  {
 			name = "unknown";
+			baseType = 0;
 			length = 1;
 			isarray = false;
 			sampledImage = kSampledImageUnknown;
@@ -47,6 +49,14 @@ namespace krafix {
 			isMultiSampledImage = false;
 		}
 		Type() : Type(spv::OpNop) {}
+	};
+
+	struct Member {
+		unsigned type;
+		const char* name;
+		bool isColumnMajor;
+
+		Member() : name("unknown"), isColumnMajor(true) {}
 	};
 
 	struct Name {
@@ -80,6 +90,7 @@ namespace krafix {
 		std::map<unsigned, Name> names;
 		std::map<unsigned, Type> types;
 		std::map<unsigned, Variable> variables;
+		std::map<unsigned, Member> members;
 		std::map<unsigned, std::string> labelStarts;
 		std::map<unsigned, Merge> merges;
 		std::map<unsigned, std::string> references;
@@ -100,5 +111,6 @@ namespace krafix {
 		void indent(std::ostream* out);
 		void output(std::ostream* out);
 		std::string getReference(unsigned _id);
+		inline unsigned getMemberId(unsigned typeId, unsigned member) { return (typeId << 16) + member; }
 	};
 }

--- a/Sources/CStyleTranslator.h
+++ b/Sources/CStyleTranslator.h
@@ -6,6 +6,13 @@
 #include <sstream>
 
 namespace krafix {
+
+	typedef enum {
+		kSampledImageUnknown = 0,
+		kSampledImageYes = 1,
+		kSampledImageNo = 2,
+	} SampledImage;
+
 	struct Variable {
 		unsigned id;
 		unsigned type;
@@ -21,11 +28,25 @@ namespace krafix {
 	};
 
 	struct Type {
+		spv::Op opcode;
 		const char* name;
 		unsigned length;
+		SampledImage sampledImage;
+		spv::Dim imageDim;
+		bool isDepthImage;
+		bool isMultiSampledImage;
 		bool isarray;
 
-		Type() : name("unknown"), length(1), isarray(false) {}
+		Type(spv::Op opcode) : opcode(opcode)  {
+			name = "unknown";
+			length = 1;
+			isarray = false;
+			sampledImage = kSampledImageUnknown;
+			imageDim = spv::Dim2D;
+			isDepthImage = false;
+			isMultiSampledImage = false;
+		}
+		Type() : Type(spv::OpNop) {}
 	};
 
 	struct Name {

--- a/Sources/MetalStageInTranslator.cpp
+++ b/Sources/MetalStageInTranslator.cpp
@@ -1,9 +1,8 @@
 
 #include "MetalStageInTranslator.h"
 
-#pragma mark -
-#pragma mark MetalStageInTranslator
-
+using namespace krafix;
+using namespace spv;
 
 void MetalStageInTranslator::outputCode(const Target& target,
 										const MetalStageInTranslatorRenderContext& renderContext,
@@ -185,9 +184,7 @@ void MetalStageInTranslator::outputInstruction(const Target& target,
 	}
 }
 
-
-#pragma mark Output functions
-
+/** Outputs a function signature. */
 void MetalStageInTranslator::outputFunctionSignature(bool asDeclaration) {
 	if (_isEntryFunction) {
 		outputEntryFunctionSignature(asDeclaration);
@@ -196,7 +193,7 @@ void MetalStageInTranslator::outputFunctionSignature(bool asDeclaration) {
 	}
 }
 
-/** Ouptus the function signature of the entry function. */
+/** Outputs the function signature of an entry function. */
 void MetalStageInTranslator::outputEntryFunctionSignature(bool asDeclaration) {
 
 	// If this is a declaration, output entry point function input and output variables
@@ -286,6 +283,7 @@ void MetalStageInTranslator::outputEntryFunctionSignature(bool asDeclaration) {
 	closeFunctionSignature(asDeclaration);
 }
 
+/** Outputs the function signature of a local function. */
 void MetalStageInTranslator::outputLocalFunctionSignature(bool asDeclaration) {
 	indent(out);
 	(*out) << funcType << " " << funcName << "(";
@@ -293,6 +291,7 @@ void MetalStageInTranslator::outputLocalFunctionSignature(bool asDeclaration) {
 	closeFunctionSignature(asDeclaration);
 }
 
+/** Outputs the function parameters for the current function. */
 bool MetalStageInTranslator::outputFunctionParameters(bool asDeclaration, bool needsComma) {
 	for (std::vector<Parameter>::iterator iter = parameters.begin(), end = parameters.end(); iter != end; iter++) {
 		needsComma = paramComma(needsComma);
@@ -505,9 +504,6 @@ bool MetalStageInTranslator::outputStageOutStruct() {
 	return hasStageOut;
 }
 
-
-#pragma mark Support member functions
-
 /** Returns the shader stage corresponding to the specified SPIRV execution model. */
 EShLanguage MetalStageInTranslator::stageFromSPIRVExecutionModel(ExecutionModel execModel) {
 	switch (execModel) {
@@ -563,15 +559,12 @@ bool MetalStageInTranslator::paramComma(bool needsComma) {
 }
 
 
-#pragma mark -
-#pragma mark Support functions
-
-std::string& cleanMSLFuncName(std::string& funcName) {
+std::string& krafix::cleanMSLFuncName(std::string& funcName) {
 	static std::string _cleanMainFuncName = "mmain";
 	return (funcName == "main") ? _cleanMainFuncName : funcName;
 }
 
-bool compareByLocation(KrafixVarPair* vp1, KrafixVarPair* vp2) {
+bool krafix::compareByLocation(KrafixVarPair* vp1, KrafixVarPair* vp2) {
 	Variable& v1 = vp1->second;
 	Variable& v2 = vp2->second;
 	if ( !v1.builtin && v2.builtin) { return true; }

--- a/Sources/MetalStageInTranslator.cpp
+++ b/Sources/MetalStageInTranslator.cpp
@@ -1,0 +1,581 @@
+
+#include "MetalStageInTranslator.h"
+
+#pragma mark -
+#pragma mark MetalStageInTranslator
+
+
+void MetalStageInTranslator::outputCode(const Target& target,
+										const MetalStageInTranslatorRenderContext& renderContext,
+										std::ostream* pOutput,
+										std::map<std::string, int>& attributes) {
+	out = pOutput;
+	_renderContext = renderContext;
+
+	_nextMTLBufferIndex = 0;
+	_nextMTLTextureIndex = 0;
+	_nextMTLSamplerIndex = 0;
+
+	outputHeader();
+	
+	for (unsigned i = 0; i < instructions.size(); ++i) {
+		outputting = false;
+		Instruction& inst = instructions[i];
+		outputInstruction(target, attributes, inst);
+		if (outputting) { (*out) << "\n"; }
+	}
+
+	for (std::vector<Function*>::iterator iter = functions.begin(), end = functions.end(); iter != end; iter++) {
+		(*out) << (*iter)->text.str();
+		(*out) << "\n\n";
+	}
+}
+
+void MetalStageInTranslator::outputHeader() {
+	(*out) << "#include <metal_stdlib>\n";
+	(*out) << "#include <simd/simd.h>\n";
+	(*out) << "\n";
+	(*out) << "using namespace metal;\n";
+	(*out) << "\n";
+}
+
+void MetalStageInTranslator::outputInstruction(const Target& target,
+										   std::map<std::string, int>& attributes,
+										   Instruction& inst) {
+	switch (inst.opcode) {
+
+		case OpEntryPoint: {
+			stage = stageFromSPIRVExecutionModel((ExecutionModel)inst.operands[0]);
+			entryPoint = inst.operands[1];
+			name = std::string(inst.string);
+			name = cleanMSLFuncName(name);
+			break;
+		}
+
+		case OpVariable: {
+			unsigned id = inst.operands[1];
+			Variable& v = variables[id];
+			v.type = inst.operands[0];
+			v.storage = (StorageClass)inst.operands[2];
+			v.declared = (v.storage == StorageClassInput ||
+						  v.storage == StorageClassOutput ||
+						  v.storage == StorageClassUniform ||
+						  v.storage == StorageClassUniformConstant ||
+						  v.storage == StorageClassPushConstant);
+
+			std::string varName = getVariableName(id);
+			Type t = types[v.type];
+			if (t.opcode == OpTypePointer) { t = types[t.baseType]; }
+
+			if (v.storage == StorageClassInput) {
+				const char* vPfx = v.builtin ? "" : "in.";
+				if (strcmp(t.name, "float2") == 0 || strcmp(t.name, "float3") == 0 || strcmp(t.name, "float4") == 0) {
+					references[id] = std::string(t.name) + "(" + vPfx + varName + ")";
+				} else {
+					references[id] = std::string(vPfx) + varName;
+				}
+			}
+			else if (v.storage == StorageClassOutput) {
+				if (t.opcode != OpTypeStruct) {
+					references[id] = std::string("out.") + varName;
+				} else {
+					references[id] = "out";
+				}
+			}
+			else {
+				if (isUniformBufferMember(v, t)) {
+					references[id] = std::string("uniforms.") + varName;
+				} else {
+					references[id] = varName;
+				}
+			}
+			break;
+		}
+
+		case OpFunction: {
+			// Almost identical behaviour as CStyleTranslator.
+			// Overriding to avoid MetalTranslator implementation.
+			firstLabel = true;
+			parameters.clear();
+
+			unsigned result = inst.operands[1];
+			_isEntryFunction = (result == entryPoint);
+			funcName = cleanMSLFuncName(getFunctionName(result));
+			references[result] = funcName;
+
+			Type resultType = types[inst.operands[0]];
+			types[result] = resultType;
+			funcType = resultType.name;
+			
+			break;
+		}
+
+		case OpLabel: {
+			if (firstLabel) {
+				outputFunctionSignature(true);		// Output the function delaration
+				startFunction(funcName);			// Defer output of function definition
+				outputFunctionSignature(false);		// ...by record it into a Function text
+
+				++indentation;
+				if (_isEntryFunction && _hasStageOut) {
+					output(out);
+					(*out) << funcName << "_out out;";
+				}
+				firstLabel = false;
+			} else {
+				unsigned label = inst.operands[0];
+				if (labelStarts.find(label) != labelStarts.end()) {
+					if (labelStarts[label].at(0) == '}') {
+						--indentation;
+					}
+					output(out);
+					(*out) << labelStarts[label] << "\n";
+					indent(out);
+					(*out) << "{";
+					++indentation;
+				}
+				else if (merges.find(label) != merges.end()) {
+					--indentation;
+					output(out);
+					(*out) << "}";
+				}
+			}
+			break;
+		}
+
+		case OpReturn:
+			if (_isEntryFunction && _hasStageOut) {
+				if (stage == EShLangVertex && _renderContext.shouldFlipVertexY) {
+					output(out);
+					(*out) << "out." << positionName << ".y = -out." << positionName << ".y;\t\t// Invert Y-axis for Metal\n";
+				}
+				output(out);
+				(*out) << "return out;";
+			}
+			break;
+
+		case OpImageSampleImplicitLod: {
+			unsigned result = inst.operands[1];
+			unsigned sampler = inst.operands[2];
+			unsigned coordinate = inst.operands[3];
+			Type& sType = types[sampler];
+			std::stringstream str;
+			std::string tcRef = getReference(coordinate);
+			if (_renderContext.shouldFlipFragmentY) {
+				switch (sType.imageDim) {
+					case Dim2D:
+						tcRef = "float2(" + tcRef + ".x, " + "(1.0 - " + tcRef + ".y))";
+						break;
+					case Dim3D:
+					case DimCube:
+						tcRef = "float3(" + tcRef + ".x, " + "(1.0 - " + tcRef + ".y), " + tcRef + ".z)";
+						break;
+					default:
+						break;
+				}
+			}
+			str << getReference(sampler) << ".sample(" << getReference(sampler) << "Sampler, " << tcRef << ")";
+			references[result] = str.str();
+			break;
+		}
+
+		default:
+			MetalTranslator::outputInstruction(target, attributes, inst);
+			break;
+	}
+}
+
+
+#pragma mark Output functions
+
+void MetalStageInTranslator::outputFunctionSignature(bool asDeclaration) {
+	if (_isEntryFunction) {
+		outputEntryFunctionSignature(asDeclaration);
+	} else {
+		outputLocalFunctionSignature(asDeclaration);
+	}
+}
+
+/** Ouptus the function signature of the entry function. */
+void MetalStageInTranslator::outputEntryFunctionSignature(bool asDeclaration) {
+
+	// If this is a declaration, output entry point function input and output variables
+	if (asDeclaration) {
+		_hasLooseUniforms = outputLooseUniformStruct();
+		outputUniformBuffers();
+		_hasStageIn = outputStageInStruct();
+		_hasStageOut = outputStageOutStruct();
+	}
+
+	if (_hasStageOut) { funcType = funcName + "_out"; }
+
+	// Entry functions need a type qualifier
+	std::string entryType;
+	switch (stage) {
+		case EShLangVertex:
+			entryType = "vertex";
+			break;
+		case EShLangFragment:
+			entryType = executionModes.useEarlyFragmentTests ? "fragment [[ early_fragment_tests ]]" : "fragment";
+			break;
+		case EShLangCompute:
+			entryType = "kernel";
+			break;
+		default:
+			entryType = "unknown";
+			break;
+	}
+
+	indent(out);
+	(*out) << entryType << " " << funcType << " " << funcName << "(";
+
+	bool needsComma = false;
+
+	if (_hasStageIn) {
+		needsComma = paramComma(needsComma);
+		(*out) << funcName << "_in in [[stage_in]]";
+	}
+
+	if (_hasLooseUniforms) {
+		needsComma = paramComma(needsComma);
+		(*out) << "constant " << funcName << "_uniforms& uniforms [[buffer(0)]]";
+	}
+
+	for (std::map<unsigned, Variable>::iterator v = variables.begin(); v != variables.end(); ++v) {
+		unsigned id = v->first;
+		Variable& variable = v->second;
+
+		Type t = types[variable.type];
+		if (t.opcode == OpTypePointer) { t = types[t.baseType]; }
+		std::string varName = getVariableName(id);
+
+		if (variable.storage == StorageClassUniform ||
+			variable.storage == StorageClassUniformConstant ||
+			variable.storage == StorageClassPushConstant) {
+			switch (t.opcode) {
+				case OpTypeStruct:
+					needsComma = paramComma(needsComma);
+					(*out) << "constant " << t.name << "& " << varName << " [[buffer(" << getMetalResourceIndex(variable, OpTypeStruct) << ")]]";
+					break;
+				case OpTypeSampler:
+					needsComma = paramComma(needsComma);
+					(*out) << t.name << " " << varName << " [[sampler(" << getMetalResourceIndex(variable, OpTypeSampler) << ")]]";
+					break;
+				case OpTypeImage:
+					needsComma = paramComma(needsComma);
+					(*out) << t.name << "<float> " << varName << " [[texture(" << getMetalResourceIndex(variable, OpTypeImage) << ")]]";
+					break;
+				case OpTypeSampledImage:
+					needsComma = paramComma(needsComma);
+					(*out) << t.name << "<float> " << varName << " [[texture(" << getMetalResourceIndex(variable, OpTypeImage) << ")]]";
+					(*out) << ", sampler " << varName << "Sampler [[sampler(" << getMetalResourceIndex(variable, OpTypeSampler) << ")]]";
+					break;
+				default:
+					break;
+			}
+		}
+		if (variable.storage == StorageClassInput && variable.builtin) {
+			needsComma = paramComma(needsComma);
+			(*out) << builtInTypeName(variable.builtinType, t)
+			<< " " << varName
+			<< " [[" << builtInName(variable.builtinType) << "]]";
+		}
+	}
+
+	outputFunctionParameters(asDeclaration, needsComma);
+	closeFunctionSignature(asDeclaration);
+}
+
+void MetalStageInTranslator::outputLocalFunctionSignature(bool asDeclaration) {
+	indent(out);
+	(*out) << funcType << " " << funcName << "(";
+	outputFunctionParameters(asDeclaration, false);
+	closeFunctionSignature(asDeclaration);
+}
+
+bool MetalStageInTranslator::outputFunctionParameters(bool asDeclaration, bool needsComma) {
+	for (std::vector<Parameter>::iterator iter = parameters.begin(), end = parameters.end(); iter != end; iter++) {
+		needsComma = paramComma(needsComma);
+		(*out) << iter->type.name << " " << getReference(iter->id);
+	}
+	return needsComma;
+}
+
+void MetalStageInTranslator::closeFunctionSignature(bool asDeclaration) {
+		(*out) << (asDeclaration ? ");\n" : ") {\n");
+}
+
+/**
+ * If loose uniforms exist, collect them into a single structure and output it.
+ * Returns whether structure was output.
+ */
+bool MetalStageInTranslator::outputLooseUniformStruct() {
+	bool hasLooseUniforms = false;
+
+	std::ostringstream tmpOut;
+	indent(&tmpOut);
+	tmpOut << "struct " << funcName << "_uniforms {\n";
+	++indentation;
+	for (std::map<unsigned, Variable>::iterator v = variables.begin(); v != variables.end(); ++v) {
+		unsigned id = v->first;
+		Variable& variable = v->second;
+
+		Type t = types[variable.type];
+		if (t.opcode == OpTypePointer) { t = types[t.baseType]; }
+
+		if (isUniformBufferMember(variable, t)) {
+			tmpOut << t.name << " " << getVariableName(id);
+			if (t.isarray) { tmpOut << "[" << t.length << "]"; }
+			if (variable.builtin) { tmpOut << " [[" << builtInName(variable.builtinType) << "]]"; }
+			tmpOut << ";\n";
+			hasLooseUniforms = true;
+		}
+	}
+	--indentation;
+	indent(&tmpOut);
+	tmpOut << "};\n\n";
+
+	if (hasLooseUniforms) { (*out) << tmpOut.str(); }
+	return hasLooseUniforms;
+}
+
+/** If named uniform buffers exist, output them. */
+void MetalStageInTranslator::outputUniformBuffers() {
+	for (std::map<unsigned, Variable>::iterator v = variables.begin(); v != variables.end(); ++v) {
+		Variable& variable = v->second;
+
+		unsigned typeId = variable.type;
+		Type t = types[typeId];
+		if (t.opcode == OpTypePointer) {
+			typeId = t.baseType;
+			t = types[typeId];
+		}
+
+		if ((t.opcode == OpTypeStruct) && (variable.storage != StorageClassOutput)) {
+			indent(out);
+			(*out) << "struct " << t.name << " {\n";
+			++indentation;
+			for (unsigned mbrIdx = 0; mbrIdx < t.length; mbrIdx++) {
+				unsigned mbrId = getMemberId(typeId, mbrIdx);
+				Member member = members[mbrId];
+				Type mbrType = types[member.type];
+				indent(out);
+				(*out) << mbrType.name << " " << member.name;
+				if (mbrType.isarray) { (*out) << "[" << mbrType.length << "]"; }
+				(*out) << ";\n";
+			}
+			--indentation;
+			indent(out);
+			(*out) << "};\n\n";
+		}
+	}
+}
+/**
+ * If attribute inputs exist, collect them into a single stage-in structure, in location order,
+ * and output the structure. Returns whether structure was output.
+ */
+bool MetalStageInTranslator::outputStageInStruct() {
+	std::ostringstream tmpOut;
+
+	std::vector<std::pair<const unsigned, Variable>*> inVars;
+	for (std::map<unsigned, Variable>::iterator v = variables.begin(); v != variables.end(); ++v) {
+		Variable& variable = v->second;
+		if (variable.storage == StorageClassInput && !variable.builtin) {
+			inVars.push_back(&(*v));
+		}
+	}
+	unsigned varCnt = (unsigned)inVars.size();
+	if (varCnt == 0) { return false; }		// No stage-in attributes to output
+
+	std::sort (inVars.begin(), inVars.end(), compareByLocation);
+	(*out) << "struct " << funcName << "_in {\n";
+	++indentation;
+	for (unsigned varIdx = 0; varIdx < varCnt; varIdx++) {
+		auto pVar = inVars[varIdx];
+		unsigned id = pVar->first;
+		Variable& variable = pVar->second;
+
+		Type t = types[variable.type];
+
+		indent(out);
+		(*out) << t.name << " " << getVariableName(id);
+		switch (stage) {
+			case EShLangVertex:
+				(*out) << " [[attribute("
+				<< std::max(variable.location, varIdx)	// Auto increment if locations were not specified
+				<< ")]]";
+				break;
+			default:
+				break;
+		}
+		(*out) << ";\n";
+	}
+	--indentation;
+	indent(out);
+	(*out) << "};\n\n";
+
+	return true;
+}
+
+/** Collect shader output into the output structure and output it. Returns whether output structure was output. */
+bool MetalStageInTranslator::outputStageOutStruct() {
+	bool hasStageOut = false;
+
+	std::ostringstream tmpOut;
+	indent(&tmpOut);
+	tmpOut << "struct " << funcName << "_out {\n";
+	++indentation;
+	for (std::map<unsigned, Variable>::iterator v = variables.begin(); v != variables.end(); ++v) {
+		unsigned id = v->first;
+		Variable& variable = v->second;
+
+		if (variable.storage == StorageClassOutput) {
+			unsigned typeId = variable.type;
+			Type t = types[typeId];
+			if (t.opcode == OpTypePointer) {
+				typeId = t.baseType;
+				t = types[typeId];
+			}
+			std::string varName = getVariableName(id);
+
+			if (t.opcode == OpTypeStruct) {
+				// Extract struct members and add them to stage-out struct
+				for (unsigned mbrIdx = 0; mbrIdx < t.length; mbrIdx++) {
+					unsigned mbrId = getMemberId(typeId, mbrIdx);
+					Member member = members[mbrId];
+					Type mbrType = types[member.type];
+					indent(&tmpOut);
+					tmpOut << mbrType.name << " " << member.name;
+					if (mbrType.isarray) { tmpOut << "[" << mbrType.length << "]"; }
+					if (member.builtin) {
+						switch (member.builtinType) {
+							case BuiltInPosition:
+								tmpOut << " [[" << builtInName(member.builtinType) << "]]";
+								positionName = member.name;
+								break;
+							case spv::BuiltInPointSize:
+								if (_renderContext.isRenderingPoints) {
+									tmpOut << " [[" << builtInName(member.builtinType) << "]]";
+								}
+								break;
+							case BuiltInClipDistance:
+								tmpOut << "  /* [[clip_distance]] built-in unsupported under Metal */";
+								break;
+							default:
+								tmpOut << " [[" << builtInName(member.builtinType) << "]]";
+								break;
+						}
+					}
+					tmpOut << ";\n";
+					hasStageOut = true;
+				}
+			} else {
+				indent(&tmpOut);
+				tmpOut << t.name << " " << varName;
+				if (t.isarray) { tmpOut << "[" << t.length << "]"; }
+				if (variable.builtin) {
+					switch (variable.builtinType) {
+						case BuiltInPosition:
+							tmpOut << " [[" << builtInName(variable.builtinType) << "]]";
+							positionName = varName;
+							break;
+						case spv::BuiltInPointSize:
+							if (_renderContext.isRenderingPoints) {
+								tmpOut << " [[" << builtInName(variable.builtinType) << "]]";
+							}
+							break;
+						case BuiltInClipDistance:
+							tmpOut << "  /* [[clip_distance]] built-in unsupported under Metal */";
+							break;
+						default:
+							tmpOut << " [[" << builtInName(variable.builtinType) << "]]";
+							break;
+					}
+				}
+				tmpOut << ";\n";
+				hasStageOut = true;
+			}
+		}
+	}
+	--indentation;
+	indent(&tmpOut);
+	tmpOut << "};\n\n";
+
+	if (hasStageOut) { (*out) << tmpOut.str(); }
+	return hasStageOut;
+}
+
+
+#pragma mark Support member functions
+
+/** Returns the shader stage corresponding to the specified SPIRV execution model. */
+EShLanguage MetalStageInTranslator::stageFromSPIRVExecutionModel(ExecutionModel execModel) {
+	switch (execModel) {
+		case ExecutionModelVertex:					return EShLangVertex;
+		case ExecutionModelTessellationControl:		return EShLangTessControl;
+		case ExecutionModelTessellationEvaluation:	return EShLangTessEvaluation;
+		case ExecutionModelGeometry:				return EShLangGeometry;
+		case ExecutionModelFragment:				return EShLangFragment;
+		case ExecutionModelGLCompute:				return EShLangCompute;
+		case ExecutionModelKernel:					return EShLangCompute;
+	}
+}
+
+/** 
+ * Returns the Metal index of the resource of the specified type as used by the specified variable.
+ *
+ * This implementation simply increments the value of each type of Metal resource index on
+ * each request. This function can be overridden by subclasses to provide a different mechanism
+ * for associating shader variables with Metal resource indexes, such as mapping the descriptor
+ * set binding of the variable to a specific Metal resource index.
+ */
+signed MetalStageInTranslator::getMetalResourceIndex(Variable& variable, spv::Op rezType) {
+	switch (rezType) {
+		case OpTypeStruct:	return _nextMTLBufferIndex++;
+		case OpTypeImage:	return _nextMTLTextureIndex++;
+		case OpTypeSampler:	return _nextMTLSamplerIndex++;
+		default:			return 0;
+	}
+}
+
+bool MetalStageInTranslator::isUniformBufferMember(Variable& var, Type& type) {
+	using namespace spv;
+
+	if (var.storage != StorageClassUniformConstant) { return false; }
+
+	switch (type.opcode) {
+		case OpTypeBool:
+		case OpTypeInt:
+		case OpTypeFloat:
+		case OpTypeVector:
+		case OpTypeMatrix:
+		case OpTypeStruct:
+			return true;
+		default:
+			return false;
+	}
+}
+
+/** Outputs a parameter-separating comma if needed, and returns the need for further commas. */
+bool MetalStageInTranslator::paramComma(bool needsComma) {
+	if (needsComma) { (*out) << ", "; }
+	return true;
+}
+
+
+#pragma mark -
+#pragma mark Support functions
+
+std::string& cleanMSLFuncName(std::string& funcName) {
+	static std::string _cleanMainFuncName = "mmain";
+	return (funcName == "main") ? _cleanMainFuncName : funcName;
+}
+
+bool compareByLocation(KrafixVarPair* vp1, KrafixVarPair* vp2) {
+	Variable& v1 = vp1->second;
+	Variable& v2 = vp2->second;
+	if ( !v1.builtin && v2.builtin) { return true; }
+	return v1.location < v2.location;
+}
+
+

--- a/Sources/MetalStageInTranslator.h
+++ b/Sources/MetalStageInTranslator.h
@@ -9,83 +9,76 @@
 #include <sstream>
 
 
-using namespace krafix;
-using namespace spv;
+namespace krafix {
 
-/** The rendering context in which a shader conversion occurs. */
-struct MetalStageInTranslatorRenderContext {
-	bool shouldFlipVertexY = true;
-	bool shouldFlipFragmentY = true;
-	bool isRenderingPoints = false;
-};
+	/** The rendering context in which a shader conversion occurs. */
+	struct MetalStageInTranslatorRenderContext {
+		bool shouldFlipVertexY = true;
+		bool shouldFlipFragmentY = true;
+		bool isRenderingPoints = false;
+	};
 
+	/** Converts SPIR-V code to Metal Shading Language Code that uses Stage-In attributes. */
+	class MetalStageInTranslator : public MetalTranslator {
 
-#pragma mark -
-#pragma mark MetalStageInTranslator
+	public:
+		using MetalTranslator::outputCode;
 
-/** Converts SPIR-V code to Metal Shading Language Code that uses Stage-In attributes. */
-class MetalStageInTranslator : public MetalTranslator {
+		/** Outputs code to the specified stream. */
+		virtual void outputCode(const Target& target,
+								const MetalStageInTranslatorRenderContext& renderContext,
+								std::ostream* pOutput,
+								std::map<std::string, int>& attributes);
 
-public:
-	using MetalTranslator::outputCode;
+		/** Output the specified instruction.  */
+		virtual void outputInstruction(const Target& target,
+									   std::map<std::string, int>& attributes,
+									   Instruction& inst);
 
-	/** Outputs code to the specified stream. */
-	virtual void outputCode(const Target& target,
-							const MetalStageInTranslatorRenderContext& renderContext,
-							std::ostream* pOutput,
-							std::map<std::string, int>& attributes);
+		/** Constructs an instance. Stage is taken from the SPIR-V itself. */
+		MetalStageInTranslator(std::vector<uint32_t>& spirv) : MetalTranslator(spirv, EShLangCount) {}
 
-	/** Output the specified instruction.  */
-	virtual void outputInstruction(const Target& target,
-								   std::map<std::string, int>& attributes,
-								   Instruction& inst);
+	protected:
+		virtual void outputHeader();
+		virtual void outputFunctionSignature(bool asDeclaration);
+		virtual void outputEntryFunctionSignature(bool asDeclaration);
+		virtual void outputLocalFunctionSignature(bool asDeclaration);
+		virtual void closeFunctionSignature(bool asDeclaration);
+		virtual bool outputFunctionParameters(bool asDeclaration, bool needsComma);
+		virtual bool outputLooseUniformStruct();
+		virtual void outputUniformBuffers();
+		virtual bool outputStageInStruct();
+		virtual bool outputStageOutStruct();
+		virtual signed getMetalResourceIndex(Variable& variable, spv::Op rezType);
+		EShLanguage stageFromSPIRVExecutionModel(spv::ExecutionModel execModel);
+		bool isUniformBufferMember(Variable& var, Type& type);
+		bool paramComma(bool needsComma);
 
-	/** Constructs an instance. Stage is taken from the SPIR-V itself. */
-	MetalStageInTranslator(std::vector<uint32_t>& spirv) : MetalTranslator(spirv, EShLangCount) {}
-
-protected:
-	virtual void outputHeader();
-	virtual void outputFunctionSignature(bool asDeclaration);
-	virtual void outputEntryFunctionSignature(bool asDeclaration);
-	virtual void outputLocalFunctionSignature(bool asDeclaration);
-	virtual void closeFunctionSignature(bool asDeclaration);
-	virtual bool outputFunctionParameters(bool asDeclaration, bool needsComma);
-	virtual bool outputLooseUniformStruct();
-	virtual void outputUniformBuffers();
-	virtual bool outputStageInStruct();
-	virtual bool outputStageOutStruct();
-	virtual signed getMetalResourceIndex(Variable& variable, spv::Op rezType);
-	EShLanguage stageFromSPIRVExecutionModel(ExecutionModel execModel);
-	bool isUniformBufferMember(Variable& var, Type& type);
-	bool paramComma(bool needsComma);
-
-	MetalStageInTranslatorRenderContext _renderContext;
-	unsigned _nextMTLBufferIndex;
-	unsigned _nextMTLTextureIndex;
-	unsigned _nextMTLSamplerIndex;
-	bool _hasLooseUniforms;
-	bool _hasStageIn;
-	bool _hasStageOut;
-	bool _isEntryFunction;
-};
+		MetalStageInTranslatorRenderContext _renderContext;
+		unsigned _nextMTLBufferIndex;
+		unsigned _nextMTLTextureIndex;
+		unsigned _nextMTLSamplerIndex;
+		bool _hasLooseUniforms;
+		bool _hasStageIn;
+		bool _hasStageOut;
+		bool _isEntryFunction;
+	};
 
 
-#pragma mark -
-#pragma mark Support functions
-
-/** 
- * Cleans the specified shader function name so it can be used as as an MSL function name.
- * The cleansed name is returned. The original name is left unmodified.
- */
-std::string& cleanMSLFuncName(std::string& funcName);
+	/**
+	 * Cleans the specified shader function name so it can be used as as an MSL function name.
+	 * The cleansed name is returned. The original name is left unmodified.
+	 */
+	std::string& cleanMSLFuncName(std::string& funcName);
 
 
-typedef std::pair<const unsigned, Variable> KrafixVarPair;
+	typedef std::pair<const unsigned, Variable> KrafixVarPair;
 
-/**
- * When sorting a map of variables, returns whether the variable in the first map pair
- * has a lower location than the second. Built-in variables have no location and will
- * appear at the end of the list.
- */
-bool compareByLocation(KrafixVarPair* vp1, KrafixVarPair* vp2);
+	/**
+	 * When sorting a map of variables, returns whether the variable in the first map pair
+	 * has a lower location than the second. Built-in variables have no location and will
+	 * appear at the end of the list.
+	 */
+	bool compareByLocation(KrafixVarPair* vp1, KrafixVarPair* vp2);
 
+}

--- a/Sources/MetalStageInTranslator.h
+++ b/Sources/MetalStageInTranslator.h
@@ -1,0 +1,91 @@
+
+#pragma once
+
+#include "MetalTranslator.h"
+
+#include <vector>
+#include <map>
+#include <string>
+#include <sstream>
+
+
+using namespace krafix;
+using namespace spv;
+
+/** The rendering context in which a shader conversion occurs. */
+struct MetalStageInTranslatorRenderContext {
+	bool shouldFlipVertexY = true;
+	bool shouldFlipFragmentY = true;
+	bool isRenderingPoints = false;
+};
+
+
+#pragma mark -
+#pragma mark MetalStageInTranslator
+
+/** Converts SPIR-V code to Metal Shading Language Code that uses Stage-In attributes. */
+class MetalStageInTranslator : public MetalTranslator {
+
+public:
+	using MetalTranslator::outputCode;
+
+	/** Outputs code to the specified stream. */
+	virtual void outputCode(const Target& target,
+							const MetalStageInTranslatorRenderContext& renderContext,
+							std::ostream* pOutput,
+							std::map<std::string, int>& attributes);
+
+	/** Output the specified instruction.  */
+	virtual void outputInstruction(const Target& target,
+								   std::map<std::string, int>& attributes,
+								   Instruction& inst);
+
+	/** Constructs an instance. Stage is taken from the SPIR-V itself. */
+	MetalStageInTranslator(std::vector<uint32_t>& spirv) : MetalTranslator(spirv, EShLangCount) {}
+
+protected:
+	virtual void outputHeader();
+	virtual void outputFunctionSignature(bool asDeclaration);
+	virtual void outputEntryFunctionSignature(bool asDeclaration);
+	virtual void outputLocalFunctionSignature(bool asDeclaration);
+	virtual void closeFunctionSignature(bool asDeclaration);
+	virtual bool outputFunctionParameters(bool asDeclaration, bool needsComma);
+	virtual bool outputLooseUniformStruct();
+	virtual void outputUniformBuffers();
+	virtual bool outputStageInStruct();
+	virtual bool outputStageOutStruct();
+	virtual signed getMetalResourceIndex(Variable& variable, spv::Op rezType);
+	EShLanguage stageFromSPIRVExecutionModel(ExecutionModel execModel);
+	bool isUniformBufferMember(Variable& var, Type& type);
+	bool paramComma(bool needsComma);
+
+	MetalStageInTranslatorRenderContext _renderContext;
+	unsigned _nextMTLBufferIndex;
+	unsigned _nextMTLTextureIndex;
+	unsigned _nextMTLSamplerIndex;
+	bool _hasLooseUniforms;
+	bool _hasStageIn;
+	bool _hasStageOut;
+	bool _isEntryFunction;
+};
+
+
+#pragma mark -
+#pragma mark Support functions
+
+/** 
+ * Cleans the specified shader function name so it can be used as as an MSL function name.
+ * The cleansed name is returned. The original name is left unmodified.
+ */
+std::string& cleanMSLFuncName(std::string& funcName);
+
+
+typedef std::pair<const unsigned, Variable> KrafixVarPair;
+
+/**
+ * When sorting a map of variables, returns whether the variable in the first map pair
+ * has a lower location than the second. Built-in variables have no location and will
+ * appear at the end of the list.
+ */
+bool compareByLocation(KrafixVarPair* vp1, KrafixVarPair* vp2);
+

--- a/Sources/MetalTranslator.cpp
+++ b/Sources/MetalTranslator.cpp
@@ -422,14 +422,6 @@ void MetalTranslator::outputInstruction(const Target& target, std::map<std::stri
 			output(out);
 			(*out) << "}";
 			break;
-		case OpCompositeConstruct: {
-			//Type resultType = types[inst.operands[0]];
-			id result = inst.operands[1];
-			std::stringstream str;
-			str << "float4(" << getReference(inst.operands[2]) << ", " << getReference(inst.operands[3]) << ", " << getReference(inst.operands[4]) << ", " << getReference(inst.operands[5]) << ")";
-			references[result] = str.str();
-			break;
-		}
 		case OpMatrixTimesVector: {
 			//Type resultType = types[inst.operands[0]];
 			id result = inst.operands[1];

--- a/Sources/MetalTranslator.cpp
+++ b/Sources/MetalTranslator.cpp
@@ -95,11 +95,11 @@ void MetalTranslator::outputInstruction(const Target& target, std::map<std::stri
 		case OpTypeArray: {
 			unsigned id = inst.operands[0];
 			unsigned reftype = inst.operands[1];
-			Type t = types[reftype];		// Pass through referenced type
-			t.opcode = inst.opcode;			// ...except OpCode
-			t.baseType = reftype;			// ...and base type
-			t.length = inst.operands[2];	// ...and length
-			t.isarray = true;				// ...and array marker	
+			Type t = types[reftype];								// Pass through referenced type
+			t.opcode = inst.opcode;									// ...except OpCode
+			t.baseType = reftype;									// ...and base type
+			t.length = atoi(references[inst.operands[2]].c_str());	// ...and length
+			t.isarray = true;										// ...and array marker
 			types[id] = t;
 			break;
 		}

--- a/Sources/MetalTranslator.cpp
+++ b/Sources/MetalTranslator.cpp
@@ -56,7 +56,7 @@ void MetalTranslator::outputInstruction(const Target& target, std::map<std::stri
 		case OpExecutionMode:
 			break;
 		case OpTypeArray: {
-			Type t;
+			Type t(inst.opcode);
 			unsigned id = inst.operands[0];
 			t.name = "?[]";
 			Type subtype = types[inst.operands[1]];
@@ -75,7 +75,7 @@ void MetalTranslator::outputInstruction(const Target& target, std::map<std::stri
 			break;
 		}
 		case OpTypeVector: {
-			Type t;
+			Type t(inst.opcode);
 			unsigned id = inst.operands[0];
 			t.name = "float?";
 			Type subtype = types[inst.operands[1]];
@@ -97,7 +97,7 @@ void MetalTranslator::outputInstruction(const Target& target, std::map<std::stri
 			break;
 		}
 		case OpTypeMatrix: {
-			Type t;
+			Type t(inst.opcode);
 			unsigned id = inst.operands[0];
 			t.name = "matrix_float4x?";
 			Type subtype = types[inst.operands[1]];
@@ -110,8 +110,50 @@ void MetalTranslator::outputInstruction(const Target& target, std::map<std::stri
 			}
 			break;
 		}
+		case OpTypeImage: {
+			Type t(inst.opcode);
+			unsigned id = inst.operands[0];
+			t.imageDim = (spv::Dim)inst.operands[2];
+			t.isDepthImage = (inst.operands[3] == 1);
+			t.isarray = !!(inst.operands[4]);
+			t.isMultiSampledImage = !!(inst.operands[5]);
+			t.sampledImage = (SampledImage)inst.operands[6];
+
+			if (t.isDepthImage) {
+				switch (t.imageDim) {
+					case spv::Dim2D:
+						t.name = t.isMultiSampledImage ? "depth2d_ms" : (t.isarray ? "depth2d_array" : "depth2d");
+						break;
+					case spv::DimCube:
+						t.name = t.isarray ? "depthcube_array" : "depthcube";
+						break;
+					default:
+						break;
+				}
+			} else {
+				switch (t.imageDim) {
+					case spv::Dim1D:
+						t.name = t.isarray ? "texture1d_array" : "texture1d";
+						break;
+					case spv::Dim2D:
+						t.name = t.isMultiSampledImage ? "texture2d_ms" : (t.isarray ? "texture2d_array" : "texture2d");
+						break;
+					case spv::Dim3D:
+						t.name = "texture3D";
+						break;
+					case spv::DimCube:
+						t.name = t.isarray ? "texturecube_array" : "texturecube";
+						break;
+					default:
+						break;
+				}
+			}
+
+			types[id] = t;
+			break;
+		}
 		case OpTypeSampler: {
-			Type t;
+			Type t(inst.opcode);
 			unsigned id = inst.operands[0];
 			t.name = "sampler2D";
 			types[id] = t;

--- a/Sources/MetalTranslator.cpp
+++ b/Sources/MetalTranslator.cpp
@@ -416,6 +416,12 @@ void MetalTranslator::outputInstruction(const Target& target, std::map<std::stri
 			else (*out) << "float4 output;";
 			break;
 		}
+		case OpFunctionEnd:
+			// Don't call endFunction()
+			--indentation;
+			output(out);
+			(*out) << "}";
+			break;
 		case OpCompositeConstruct: {
 			//Type resultType = types[inst.operands[0]];
 			id result = inst.operands[1];

--- a/Sources/MetalTranslator.cpp
+++ b/Sources/MetalTranslator.cpp
@@ -9,8 +9,6 @@ using namespace krafix;
 typedef unsigned id;
 
 namespace {
-	std::string positionName = "position";
-
 	std::string extractFilename(std::string path) {
 		int i = (int)path.size() - 1;
 		for (; i > 0; --i) {

--- a/Sources/MetalTranslator.cpp
+++ b/Sources/MetalTranslator.cpp
@@ -416,12 +416,6 @@ void MetalTranslator::outputInstruction(const Target& target, std::map<std::stri
 			else (*out) << "float4 output;";
 			break;
 		}
-		case OpFunctionEnd:
-			// Don't call endFunction()
-			--indentation;
-			output(out);
-			(*out) << "}";
-			break;
 		case OpMatrixTimesVector: {
 			//Type resultType = types[inst.operands[0]];
 			id result = inst.operands[1];

--- a/Sources/MetalTranslator.h
+++ b/Sources/MetalTranslator.h
@@ -8,7 +8,8 @@ namespace krafix {
 		MetalTranslator(std::vector<unsigned>& spirv, EShLanguage stage) : CStyleTranslator(spirv, stage) {}
 		void outputCode(const Target& target, const char* filename, std::map<std::string, int>& attributes);
 		void outputInstruction(const Target& target, std::map<std::string, int>& attributes, Instruction& inst);
-	private:
-		std::string name;
+	protected:
+		std::string name = "main";
+		std::string positionName = "position";
 	};
 }

--- a/Sources/MetalTranslator.h
+++ b/Sources/MetalTranslator.h
@@ -9,6 +9,9 @@ namespace krafix {
 		void outputCode(const Target& target, const char* filename, std::map<std::string, int>& attributes);
 		void outputInstruction(const Target& target, std::map<std::string, int>& attributes, Instruction& inst);
 	protected:
+		const char* builtInName(spv::BuiltIn builtin);
+		const char* builtInTypeName(spv::BuiltIn builtin, Type& type);
+
 		std::string name;
 		std::string positionName = "position";
 	};

--- a/Sources/MetalTranslator.h
+++ b/Sources/MetalTranslator.h
@@ -9,7 +9,7 @@ namespace krafix {
 		void outputCode(const Target& target, const char* filename, std::map<std::string, int>& attributes);
 		void outputInstruction(const Target& target, std::map<std::string, int>& attributes, Instruction& inst);
 	protected:
-		std::string name = "main";
+		std::string name;
 		std::string positionName = "position";
 	};
 }

--- a/Sources/Translator.cpp
+++ b/Sources/Translator.cpp
@@ -21,6 +21,9 @@ Instruction::Instruction(std::vector<unsigned>& spirv, unsigned& index) {
 	case OpMemberName:
 		string = (char*)&spirv[index + 3];
 		break;
+	case OpSourceExtension:
+		string = (char*)&spirv[index + 1];
+		break;
 	default:
 		string = NULL;
 		break;

--- a/Sources/Translator.cpp
+++ b/Sources/Translator.cpp
@@ -18,6 +18,9 @@ Instruction::Instruction(std::vector<unsigned>& spirv, unsigned& index) {
 	case OpName:
 		string = (char*)&spirv[index + 2];
 		break;
+	case OpMemberName:
+		string = (char*)&spirv[index + 3];
+		break;
 	default:
 		string = NULL;
 		break;

--- a/Sources/Translator.cpp
+++ b/Sources/Translator.cpp
@@ -21,6 +21,9 @@ Instruction::Instruction(std::vector<unsigned>& spirv, unsigned& index) {
 	case OpMemberName:
 		string = (char*)&spirv[index + 3];
 		break;
+	case OpEntryPoint:
+		string = (char*)&spirv[index + 3];
+		break;
 	case OpSourceExtension:
 		string = (char*)&spirv[index + 1];
 		break;


### PR DESCRIPTION
Hi Rob...

Wonderful architecture! Quite succinct and easy to expand.

We're using krafix as part of MetalVK, a larger project to run Vulkan on top of Metal on iOS & OS X. Metal support in krafix is a great start, and we've made a number of changes to add enhancements, as in the attached pull request. We've tried to keep the changes as non-disruptive as possible, but since we're only interest in Metal, none of these changes have been tested against the other krafix translators.

Our main Metal conversion is handled in a subclass of MetalTranslator, but which is not part of this repo yet. The reason we chose to do that is because our approach was not easily compatible with the MetalTranslator. In our subclass, we use stage-in attributes instead of vertex indexes, need to handle larger shaders with multiple functions, and pass in structures to map descriptor set bindings to Metal resource indices.

Anyway, I thought we'd offer to contribute what makes sense. With that in mind, what are your future plans for Metal support? Is that something we could contribute to directly? If Metal is not something that you've got significant investment in, we do, so perhaps we could work out a way for us to contribute what we can to that segment.

I'd also like to discuss design approaches to other issues. In the past month, we added Member support as first-class objects. In doing the most recent merge, I see you've added Members now, but with a different approach. Perhaps we could discuss options there. We need to be able to handle decorations, etc, hence our design choice. In addition, we need to add better Function support. For some reason, SPIR-V encodes functions in reverse order, relative to how they have to be spit out. Something to discuss from a design perspective.

Thanks...

...Bill
