### PR TITLE
MetalTranslator support OpConstantComposite and OpStore.

### DIFF
--- a/Sources/CStyleTranslator.cpp
+++ b/Sources/CStyleTranslator.cpp
@@ -47,7 +47,7 @@ void CStyleTranslator::addUniqueName(unsigned id, const char* name) {
 	uniqueNames[id] = uqName;				// If not found, add name unchanged
 }
 
-/** 
+/**
  * Returns the name associated with the specified ID. If a name does not yet 
  * exist for the ID, a unique name is created from the ID and the prefix string.
  * This is necessary if the SPIR-V does not contain names, or contains duplicates.
@@ -62,6 +62,7 @@ std::string& CStyleTranslator::getUniqueName(unsigned id, const char* prefix) {
 	}
 	return uqName;
 }
+
 /** Returns the name of the specified variable, creating a unique name if necessary. */
 std::string& CStyleTranslator::getVariableName(unsigned id) {
 	return getUniqueName(id, "var");
@@ -79,6 +80,16 @@ std::string& CStyleTranslator::getFunctionName(unsigned id) {
 
 std::string CStyleTranslator::getNextTempName() {
 	return tempNamePrefix + std::to_string(tempNameIndex++);
+}
+
+unsigned CStyleTranslator::getBaseTypeID(unsigned typeID) {
+	Type& t = types[typeID];
+	return t.ispointer ? t.baseType : typeID;
+}
+
+Type& CStyleTranslator::getBaseType(unsigned typeID) {
+	Type& t = types[typeID];
+	return t.ispointer ? types[t.baseType] : t;
 }
 
 /** 

--- a/Sources/CStyleTranslator.h
+++ b/Sources/CStyleTranslator.h
@@ -179,6 +179,8 @@ namespace krafix {
 		std::string& getVariableName(unsigned id);
 		std::string& getFunctionName(unsigned id);
 		std::string getNextTempName();
+		unsigned getBaseTypeID(unsigned typeID);
+		Type& getBaseType(unsigned typeID);
 		std::string outputTempVar(std::ostream* out, std::string& tmpTypeName, const std::string& rhs);
 	};
 }

--- a/Sources/MetalStageInTranslator.cpp
+++ b/Sources/MetalStageInTranslator.cpp
@@ -74,8 +74,7 @@ void MetalStageInTranslator::outputInstruction(const Target& target,
 						  v.storage == StorageClassPushConstant);
 
 			std::string varName = getVariableName(id);
-			Type t = types[v.type];
-			if (t.ispointer) { t = types[t.baseType]; }
+			Type& t = getBaseType(v.type);
 
 			if (v.storage == StorageClassInput) {
 				std::string vPfx;
@@ -317,8 +316,7 @@ void MetalStageInTranslator::outputEntryFunctionSignature(bool asDeclaration) {
 		unsigned id = v->first;
 		Variable& variable = v->second;
 
-		Type t = types[variable.type];
-		if (t.ispointer) { t = types[t.baseType]; }
+		Type& t = getBaseType(variable.type);
 		std::string varName = getVariableName(id);
 
 		if (variable.storage == StorageClassUniform ||
@@ -400,8 +398,7 @@ bool MetalStageInTranslator::outputLooseUniformStruct() {
 		unsigned id = v->first;
 		Variable& variable = v->second;
 
-		Type t = types[variable.type];
-		if (t.ispointer) { t = types[t.baseType]; }
+		Type& t = getBaseType(variable.type);
 
 		if (isUniformBufferMember(variable, t)) {
 			tmpOut << t.name << " " << getVariableName(id);
@@ -424,12 +421,8 @@ void MetalStageInTranslator::outputUniformBuffers() {
 	for (auto v = variables.begin(); v != variables.end(); ++v) {
 		Variable& variable = v->second;
 
-		unsigned typeId = variable.type;
-		Type t = types[typeId];
-		if (t.ispointer) {
-			typeId = t.baseType;
-			t = types[typeId];
-		}
+		unsigned typeId = getBaseTypeID(variable.type);
+		Type& t = types[typeId];
 
 		if ((t.opcode == OpTypeStruct) && (variable.storage != StorageClassOutput)) {
 			indent(out);
@@ -487,8 +480,7 @@ void MetalStageInTranslator::outputVertexInStructs() {
 			inStruct.byteSize = variable.offset;
 		}
 
-		Type t = types[variable.type];
-		if (t.ispointer) { t = types[t.baseType]; }
+		Type& t = getBaseType(variable.type);
 		indent(&inStruct.body);
 		if (t.opcode == OpTypeVector) { inStruct.body << "packed_"; }
 		inStruct.body << t.name << " " << getVariableName(id) << ";\n";
@@ -569,12 +561,8 @@ bool MetalStageInTranslator::outputStageOutStruct() {
 		Variable& var = v->second;
 
 		if (var.storage == StorageClassOutput) {
-			unsigned typeId = var.type;
-			Type t = types[typeId];
-			if (t.ispointer) {
-				typeId = t.baseType;
-				t = types[typeId];
-			}
+			unsigned typeId = getBaseTypeID(var.type);
+			Type& t = types[typeId];
 			std::string varName = getVariableName(id);
 
 			if (t.opcode == OpTypeStruct) {


### PR DESCRIPTION
MetalTranslator support OpConstantComposite.
MetalTranslator OpStore support array declaration.
CStyleTranslator support retrieve base type from OpPointer type.
MetalTranslator use base type functions.
MetalStageInTranslator use base type functions.
