### PR TITLE
Partial fix for graphics2 rendering on Unity.

### DIFF
--- a/Sources/HlslTranslator.cpp
+++ b/Sources/HlslTranslator.cpp
@@ -348,10 +348,10 @@ void HlslTranslator::outputInstruction(const Target& target, std::map<std::strin
 
 				if (target.system == Unity) {
 					if (stage == EShLangFragment) {
-						(*out) << "Output2 frag(Input2 input)\n";
+						(*out) << "OutputFrag frag(InputFrag input)\n";
 					}
 					else {
-						(*out) << "Output vert(Input input)\n";
+						(*out) << "OutputVert vert(InputVert input)\n";
 					}
 				}
 				else {
@@ -593,7 +593,7 @@ void HlslTranslator::outputInstruction(const Target& target, std::map<std::strin
 		t.name = "sampler2D";
 		types[id] = t;
 		break;
-	} 
+	}
 	case OpVariable: {
 		Type& resultType = types[inst.operands[0]];
 		id result = inst.operands[1];


### PR DESCRIPTION
Hi,

I had a chance to look a bit more into https://github.com/KTXSoftware/Kha/issues/261 and have found part of the problem.

I wasn't able to build krafix myself with vs2012 unfortunately (many compile errors related to missing snprintf() and other problems), but I've tested this by hand-editing the generated Unity shader files to match the source changes here. This makes things visible again at least, but images are drawn as solid coloured rectangles without any texture - any ideas on how to fix this?
