### PR TITLE
Updated Unity output to match earlier changes to input/ouput naming.

### DIFF
--- a/Sources/HlslTranslator.cpp
+++ b/Sources/HlslTranslator.cpp
@@ -348,10 +348,10 @@ void HlslTranslator::outputInstruction(const Target& target, std::map<std::strin
 
 				if (target.system == Unity) {
 					if (stage == EShLangFragment) {
-						(*out) << "Output2 frag(Input2 input)\n";
+						(*out) << "OutputFrag frag(InputFrag input)\n";
 					}
 					else {
-						(*out) << "Output vert(Input input)\n";
+						(*out) << "OutputVert vert(InputVert input)\n";
 					}
 				}
 				else {
@@ -593,7 +593,7 @@ void HlslTranslator::outputInstruction(const Target& target, std::map<std::strin
 		t.name = "sampler2D";
 		types[id] = t;
 		break;
-	} 
+	}
 	case OpVariable: {
 		Type& resultType = types[inst.operands[0]];
 		id result = inst.operands[1];


### PR DESCRIPTION
This updates the generated Unity shaders to match the naming changes in https://github.com/KTXSoftware/krafix/commit/6d40272340aa6b64b6bd36e0c0b359e4e6aa85a7 and fixes https://github.com/KTXSoftware/Kha/issues/261
