### PR TITLE
Fix doubled binding decorations for spirv output

### DIFF
--- a/Sources/SpirVTranslator.cpp
+++ b/Sources/SpirVTranslator.cpp
@@ -202,7 +202,7 @@ namespace {
 				instructionsData[instructionsDataIndex++] = 16;
 				newinstructions.push_back(dec3);
 			}
-			
+
 			if (utype == booltype || utype == inttype || utype == floattype) offset += 4;
 			else if (utype == vec2type) offset += 8;
 			else if (utype == vec3type) offset += 12;
@@ -492,7 +492,7 @@ void SpirVTranslator::outputCode(const Target& target, const char* sourcefilenam
 	bool decorationsInserted = false;
 	for (unsigned i = 0; i < instructions.size(); ++i) {
 		Instruction& inst = instructions[i];
-		
+
 		switch (state) {
 		case SpirVStart:
 			if (isDebugInformation(inst)) {
@@ -552,7 +552,7 @@ void SpirVTranslator::outputCode(const Target& target, const char* sourcefilenam
 			}
 			break;
 		}
-		
+
 		if (inst.opcode == OpEntryPoint) {
 			unsigned executionModel = inst.operands[0];
 			if (executionModel == 4) { // Fragment Shader
@@ -715,11 +715,17 @@ void SpirVTranslator::outputCode(const Target& target, const char* sourcefilenam
 				newinstructions.push_back(inst);
 			}
 		}
+		else if (inst.opcode == OpDecorate) {
+			Decoration decoration = (Decoration)inst.operands[1];
+			if (decoration != DecorationBinding) {
+				newinstructions.push_back(inst);
+			}
+		}
 		else {
 			newinstructions.push_back(inst);
 		}
 	}
-	
+
 	bound = currentId + 1;
 	writeInstructions(filename, output, newinstructions);
 }


### PR DESCRIPTION
It looks like glslang outputs the bindings now, which leads to doubled binding decorations in spirv (inspected via `spirv-dis` tool):

```
OpDecorate %myTextureSampler Binding 2
OpDecorate %myTextureSampler DescriptorSet 0
OpDecorate %myTextureSampler Binding 0
```

I tried to play with `setAutoMapBindings` and `setShiftBinding` but did not observe any effect, so this patch omits the binding decorators generated by glslang and only keeps the ones we [generate ourselves](https://github.com/Kode/krafix/blob/e98d9ba907cd7190e8c244896bf96caf010033cb/Sources/SpirVTranslator.cpp#L168):

```
OpDecorate %myTextureSampler Binding 2
OpDecorate %myTextureSampler DescriptorSet 0
```

Using this patch and my upcoming Kinc patch I witnessed a miracle and got a textured Vulkan cube to appear again.

(Completely forgot I did some related work on this two years ago https://github.com/Kode/krafix/pull/55!)