### PR TITLE
Fix returning output size for SPIRV

### DIFF
--- a/Sources/SpirVTranslator.cpp
+++ b/Sources/SpirVTranslator.cpp
@@ -74,7 +74,7 @@ namespace {
 	}
 }
 
-void SpirVTranslator::writeInstructions(const char* filename, char* output, std::vector<Instruction>& instructions) {
+int SpirVTranslator::writeInstructions(const char* filename, char* output, std::vector<Instruction>& instructions) {
 	std::ofstream fileout;
 	std::ostrstream arrayout(output, 1024 * 1024);
 	std::ostream* out;
@@ -87,23 +87,33 @@ void SpirVTranslator::writeInstructions(const char* filename, char* output, std:
 		out = &fileout;
 	}
 
+	int length = 0;
 	writeInstruction(out, magicNumber);
+	length += 4;
 	writeInstruction(out, version);
+	length += 4;
 	writeInstruction(out, generator);
+	length += 4;
 	writeInstruction(out, bound);
+	length += 4;
 	writeInstruction(out, schema);
+	length += 4;
 
 	for (unsigned i = 0; i < instructions.size(); ++i) {
 		Instruction& inst = instructions[i];
 		writeInstruction(out, ((inst.length + 1) << 16) | (unsigned)inst.opcode);
+		length += 4;
 		for (unsigned i2 = 0; i2 < inst.length; ++i2) {
 			writeInstruction(out, inst.operands[i2]);
+			length += 4;
 		}
 	}
 
 	if (!output) {
 		fileout.close();
 	}
+
+	return length;
 }
 
 namespace {
@@ -752,5 +762,5 @@ void SpirVTranslator::outputCode(const Target& target, const char* sourcefilenam
 	}
 
 	bound = currentId + 1;
-	writeInstructions(filename, output, newinstructions);
+	outputLength = writeInstructions(filename, output, newinstructions);
 }

--- a/Sources/SpirVTranslator.h
+++ b/Sources/SpirVTranslator.h
@@ -7,7 +7,8 @@ namespace krafix {
 	public:
 		SpirVTranslator(std::vector<unsigned>& spirv, ShaderStage stage) : Translator(spirv, stage) {}
 		void outputCode(const Target& target, const char* sourcefilename, const char* filename, char* output, std::map<std::string, int>& attributes) override;
+		int outputLength;
 	private:
-		void writeInstructions(const char* filename, char* output, std::vector<Instruction>& instructions);
+		int writeInstructions(const char* filename, char* output, std::vector<Instruction>& instructions);
 	};
 }

--- a/Sources/krafix.cpp
+++ b/Sources/krafix.cpp
@@ -892,6 +892,12 @@ void CompileAndLinkShaderUnits(std::vector<ShaderCompUnit> compUnits, krafix::Ta
 							if (returnCode != 0) CompileFailed = true;
 							delete[] tempoutput;
 						}
+						else if (target.lang == krafix::SpirV) {
+							translator->outputCode(target, sourcefilename, filename, output, attributes);
+							if (output != nullptr) {
+								*length = dynamic_cast<krafix::SpirVTranslator*>(translator)->outputLength;
+							}
+						}
 						else {
 							translator->outputCode(target, sourcefilename, filename, output, attributes);
 							if (output != nullptr) {


### PR DESCRIPTION
Makes using `KRAFIX_LIBRARY` for SPIRV output possible.