### PR TITLE
Enable FreeBSD binaries to be built

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -21,16 +21,6 @@ jobs:
       run: git submodule update --init --recursive
     - name: Get Kinc
       run: git clone --recursive https://github.com/Kode/Kinc.git
-
-    - name: Change to own submodule url
-      run: git -C Kinc config --file=.gitmodules submodule.Tools/kincmake.url https://github.com/tcdude/kincmake.git
-    - name: Change to FreeBSD-Build branch
-      run: git -C Kinc config --file=.gitmodules submodule.Tools/kincmake.branch FreeBSD-Build
-    - name: Sync submodule
-      run: git -C Kinc submodule sync
-    - name: Update submodule
-      run: git -C Kinc submodule update --init --recursive --remote
-
     - name: Compile in FreeBSD VM
       id: build
       uses: vmactions/freebsd-vm@v0.1.3

--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -1,0 +1,57 @@
+name: FreeBSD
+
+on:
+  push:
+    branches:
+    - master
+    - FreeBSD-Build
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  build:
+
+    runs-on: macos-latest
+    name: FreeBSD build
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Get Submodules
+      run: git submodule update --init --recursive
+    - name: Get Kinc
+      run: git clone --recursive https://github.com/Kode/Kinc.git
+
+    - name: Change to own submodule url
+      run: git -C Kinc config --file=.gitmodules submodule.Tools/kincmake.url https://github.com/tcdude/kincmake.git
+    - name: Change to FreeBSD-Build branch
+      run: git -C Kinc config --file=.gitmodules submodule.Tools/kincmake.branch FreeBSD-Build
+    - name: Sync submodule
+      run: git -C Kinc submodule sync
+    - name: Update submodule
+      run: git -C Kinc submodule update --init --recursive --remote
+
+    - name: Compile in FreeBSD VM
+      id: build
+      uses: vmactions/freebsd-vm@v0.1.3
+      with:
+        usesh: true
+        mem: 2048
+        prepare: pkg install -y node alsa-lib libXinerama mesa-libs libXi gcc
+        run: node Kinc/make --compile
+    - name: Get krafix_bin
+      run: git clone https://github.com/Kode/krafix_bin.git
+    - name: Copy binary
+      run: cp build/Release/krafix krafix_bin/krafix-freebsd
+    - name: Set name
+      run: git config --global user.name "Robbot"
+    - name: Set email
+      run: git config --global user.email "robbot2019@robdangero.us"
+    - name: Commit binary
+      run: git -C krafix_bin commit -a -m "Update Linux binary to $GITHUB_SHA."
+    - name: Tag binary
+      run: git -C krafix_bin tag freebsd_$GITHUB_SHA
+    - name: Push binary
+      run: git -C krafix_bin push https://Kode-Robbot:$ROBBOT_PASS@github.com/Kode/krafix_bin.git master --tags
+      env:
+        ROBBOT_PASS: ${{ secrets.ROBBOT_PASS }}

--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -48,7 +48,7 @@ jobs:
     - name: Set email
       run: git config --global user.email "robbot2019@robdangero.us"
     - name: Add binary
-      run: git -C kraffiti_bin add -A
+      run: git -C krafix_bin add -A
     - name: Commit binary
       run: git -C krafix_bin commit -a -m "Update Linux binary to $GITHUB_SHA."
     - name: Tag binary

--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -47,6 +47,8 @@ jobs:
       run: git config --global user.name "Robbot"
     - name: Set email
       run: git config --global user.email "robbot2019@robdangero.us"
+    - name: Add binary
+      run: git -C kraffiti_bin add -A
     - name: Commit binary
       run: git -C krafix_bin commit -a -m "Update Linux binary to $GITHUB_SHA."
     - name: Tag binary

--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -37,8 +37,8 @@ jobs:
       with:
         usesh: true
         mem: 2048
-        prepare: pkg install -y node alsa-lib libXinerama mesa-libs libXi gcc
-        run: node Kinc/make --compile
+        prepare: pkg install -y node alsa-lib libXinerama mesa-libs libXi
+        run: node Kinc/make --compile --compiler clang
     - name: Get krafix_bin
       run: git clone https://github.com/Kode/krafix_bin.git
     - name: Copy binary


### PR DESCRIPTION
This adds a github action to build a FreeBSD binary. 

> Note: This will only work once [this PR](https://github.com/Kode/kincmake/pull/113) is merged into `kincmake`!