### PR TITLE
Add action for linux-arm builds

### DIFF
--- a/.github/workflows/linux-arm.yml
+++ b/.github/workflows/linux-arm.yml
@@ -1,0 +1,96 @@
+name: Linux-ARM
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+
+
+jobs:
+  build_job:
+    runs-on: ubuntu-18.04
+    name: Build on ${{ matrix.distro }} ${{ matrix.arch }}
+
+    # Run steps for both armv6 and aarch64
+    strategy:
+      matrix:
+        include:
+          - arch: aarch64
+            distro: stretch
+          - arch: armv6
+            distro: jessie
+
+    steps:
+      - uses: actions/checkout@v2.1.0
+      - uses: uraimo/run-on-arch-action@v2.0.9
+        name: Build artifact
+        id: build
+        with:
+          arch: ${{ matrix.arch }}
+          distro: ${{ matrix.distro }}
+
+          # Not required, but speeds up builds
+          githubToken: ${{ github.token }}
+
+          # Create an artifacts directory
+          setup: |
+            mkdir -p "${PWD}/artifacts"
+
+          # Mount the artifacts directory as /artifacts in the container
+          dockerRunArgs: |
+            --volume "${PWD}/artifacts:/artifacts"
+
+          # Pass the correct artifact name
+          env: | # YAML, but pipe character is necessary
+            artifact_name: krafix-linux-${{ matrix.arch }}
+
+          # The shell to run commands with in the container
+          shell: /bin/bash
+
+          # Install some dependencies in the container. This speeds up builds if
+          # you are also using githubToken. Any dependencies installed here will
+          # be part of the container image that gets cached, so subsequent
+          # builds don't have to re-install them. The image layer is cached
+          # publicly in your project's package repository, so it is vital that
+          # no secrets are present in the container state or logs.
+          install: |
+              apt-get update -y -q
+              apt-get upgrade -y -q
+              apt-get install -y -q libasound2-dev libxinerama-dev libgl1-mesa-dev libxi-dev git build-essential
+
+          # Produce a binary artifact and place it in the mounted volume
+          run: |
+            echo " * Get Submodules"
+            git submodule update --init --recursive
+            echo " * Get Kinc"
+            git clone --recursive https://github.com/Kode/Kinc.git
+            echo " * Get Node.js"
+            git clone https://github.com/Kode/nodejs_bin.git --depth 1
+            echo " * Setup Node.js"
+            nodejs_bin/copysysbin.sh
+            echo " * Compile"
+            nodejs_bin/node Kinc/make --compile  || nodejs_bin/node-linuxarm Kinc/make --compile
+            echo " * Copying artifact"
+            cp build/Release/krafix "/artifacts/${artifact_name}"
+
+      - name: Get krafix_bin
+        run: git clone https://github.com/Kode/krafix_bin.git
+      - name: Copy armv6 binary
+        run: cp "${PWD}/artifacts/krafix-linux-armv6" krafix_bin/krafix-linux-armv6 && git -C krafix_bin add krafix-linux-armv6 || echo "armv6 not yet present..."
+      - name: Copy aarch64 binary
+        run: cp "${PWD}/artifacts/krafix-linux-aarch64" krafix_bin/krafix-linux-aarch64 && git -C krafix_bin add krafix-linux-aarch64 || echo "aarch64 not yet present..."
+      - name: Set name
+        run: git config --global user.name "Robbot"
+      - name: Set email
+        run: git config --global user.email "robbot2019@robdangero.us"
+      - name: Commit binary
+        run: git -C krafix_bin commit -a -m "Update Linux binary to $GITHUB_SHA."
+      - name: Tag binary
+        run: git -C krafix_bin tag linux_$GITHUB_SHA
+      - name: Push binary
+        run: git -C krafix_bin push https://Kode-Robbot:$ROBBOT_PASS@github.com/Kode/krafix_bin.git master --tags
+        env:
+          ROBBOT_PASS: ${{ secrets.ROBBOT_PASS }}


### PR DESCRIPTION
This PR adds a workflow to compile krafix binaries for `armv6` and `aarch64` architectures, by running the build jobs inside a Qemu VM emulating respective CPU architecture. Accomplished by using the [run-on-arch-action](https://github.com/uraimo/run-on-arch-action).