### PR TITLE
Only commit when necessary

### DIFF
--- a/.github/workflows/linux-arm.yml
+++ b/.github/workflows/linux-arm.yml
@@ -86,11 +86,16 @@ jobs:
         run: git config --global user.name "Robbot"
       - name: Set email
         run: git config --global user.email "robbot2019@robdangero.us"
+      - name: Is commit needed?
+        run: |
+          [[ `git -C krafix_bin status --porcelain` ]] && echo "NEEDCOMMIT=1" >> $GITHUB_ENV || echo "No changes to repository"
       - name: Commit binary
-        run: git -C krafix_bin commit -a -m "Update Linux-ARM binary to $GITHUB_SHA."
+        run: |
+          [[ $NEEDCOMMIT ]] && git -C krafix_bin commit -a -m "Update Linux-$BUILDARCH binary to $GITHUB_SHA." || echo "No commit necessary"
       - name: Tag binary
-        run: git -C krafix_bin tag linux$BUILDARCH-$GITHUB_SHA
+        run: |
+          [[ $NEEDCOMMIT ]] && git -C krafix_bin tag linux$BUILDARCH-$GITHUB_SHA || echo "No commit necessary"
       - name: Push binary
-        run: git -C krafix_bin push https://Kode-Robbot:$ROBBOT_PASS@github.com/Kode/krafix_bin.git master --tags
+        run: git -C krafix_bin push https://Kode-Robbot:$ROBBOT_PASS@github.com/Kode/krafix_bin.git master --tags  || echo "WARNING! Push binary failed. This is supposed to fail on forked repositories."
         env:
           ROBBOT_PASS: ${{ secrets.ROBBOT_PASS }}


### PR DESCRIPTION
This prevents build failures for the arm binaries, when a commit
fails.

Also issues a warning when pushing doesn't work, since that is
only ever supposed to work on Robs repo anyways.