### PR TITLE
Add missing `cstdint` include

### DIFF
--- a/Sources/MetalStageInTranslator.h
+++ b/Sources/MetalStageInTranslator.h
@@ -8,6 +8,7 @@
 #include <unordered_map>
 #include <string>
 #include <sstream>
+#include <cstdint>
 
 
 namespace krafix {

--- a/Sources/SpirVTranslator.h
+++ b/Sources/SpirVTranslator.h
@@ -2,6 +2,8 @@
 
 #include "Translator.h"
 
+#include <cstdint>
+
 namespace krafix {
 	class SpirVTranslator : public Translator {
 	public:


### PR DESCRIPTION
Clang 15.0.7 (possibly also previous "minor" versions of clang..) error when compiling due to missing includes